### PR TITLE
bug fix when no human presents in a frame

### DIFF
--- a/video_demo.py
+++ b/video_demo.py
@@ -128,25 +128,27 @@ def generate_bounding_boxes(kpoint, Img_data):
     '''generate sigma'''
     pts = np.array(list(zip(np.nonzero(kpoint)[1], np.nonzero(kpoint)[0])))
     leafsize = 2048
-    # build kdtree
-    tree = scipy.spatial.KDTree(pts.copy(), leafsize=leafsize)
+        
+    if pts.shape[0] > 0: # Check if there is a human presents in the frame
+        # build kdtree
+        tree = scipy.spatial.KDTree(pts.copy(), leafsize=leafsize)
 
-    distances, locations = tree.query(pts, k=4)
-    for index, pt in enumerate(pts):
-        pt2d = np.zeros(kpoint.shape, dtype=np.float32)
-        pt2d[pt[1], pt[0]] = 1.
-        if np.sum(kpoint) > 1:
-            sigma = (distances[index][1] + distances[index][2] + distances[index][3]) * 0.1
-        else:
-            sigma = np.average(np.array(kpoint.shape)) / 2. / 2.  # case: 1 point
-        sigma = min(sigma, min(Img_data.shape[0], Img_data.shape[1]) * 0.04)
+        distances, locations = tree.query(pts, k=4)
+        for index, pt in enumerate(pts):
+            pt2d = np.zeros(kpoint.shape, dtype=np.float32)
+            pt2d[pt[1], pt[0]] = 1.
+            if np.sum(kpoint) > 1:
+                sigma = (distances[index][1] + distances[index][2] + distances[index][3]) * 0.1
+            else:
+                sigma = np.average(np.array(kpoint.shape)) / 2. / 2.  # case: 1 point
+            sigma = min(sigma, min(Img_data.shape[0], Img_data.shape[1]) * 0.04)
 
-        if sigma < 6:
-            t = 2
-        else:
-            t = 2
-        Img_data = cv2.rectangle(Img_data, (int(pt[0] - sigma), int(pt[1] - sigma)),
-                                 (int(pt[0] + sigma), int(pt[1] + sigma)), (0, 255, 0), t)
+            if sigma < 6:
+                t = 2
+            else:
+                t = 2
+            Img_data = cv2.rectangle(Img_data, (int(pt[0] - sigma), int(pt[1] - sigma)),
+                                    (int(pt[0] + sigma), int(pt[1] + sigma)), (0, 255, 0), t)
 
     return Img_data
 


### PR DESCRIPTION
When no human presents in the image, the code generate an error
> Traceback (most recent call last):
  File "/home/rawan/FIDTM/video_demo.py", line 190, in <module>
    main(params)
  File "/home/rawan/FIDTM/video_demo.py", line 76, in main
    box_img = generate_bounding_boxes(pred_kpoint, frame)
  File "/home/rawan/FIDTM/video_demo.py", line 133, in generate_bounding_boxes
    tree = scipy.spatial.KDTree(pts.copy(), leafsize=leafsize)
  File "/home/rawan/miniconda3/lib/python3.9/site-packages/scipy/spatial/kdtree.py", line 337, in __init__
    super().__init__(data, leafsize, compact_nodes, copy_data,
  File "ckdtree.pyx", line 558, in scipy.spatial.ckdtree.cKDTree.__init__
ValueError: data must be 2 dimensions
